### PR TITLE
[Android 17] MediaPlayer.setAudioStreamType deprecated → setAudioAttributes 마이그레이션

### DIFF
--- a/app/src/main/java/com/sendbird/desk/android/sample/activity/chat/MediaPlayerActivity.java
+++ b/app/src/main/java/com/sendbird/desk/android/sample/activity/chat/MediaPlayerActivity.java
@@ -19,7 +19,7 @@ import android.Manifest;
 import android.app.Activity;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
-import android.media.AudioManager;
+import android.media.AudioAttributes;
 import android.media.MediaPlayer;
 import android.media.MediaPlayer.OnBufferingUpdateListener;
 import android.media.MediaPlayer.OnCompletionListener;
@@ -169,7 +169,12 @@ public class MediaPlayerActivity extends Activity implements
             mMediaPlayer.setOnCompletionListener(this);
             mMediaPlayer.setOnPreparedListener(this);
             mMediaPlayer.setOnVideoSizeChangedListener(this);
-            mMediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
+            mMediaPlayer.setAudioAttributes(
+                    new AudioAttributes.Builder()
+                            .setUsage(AudioAttributes.USAGE_MEDIA)
+                            .setContentType(AudioAttributes.CONTENT_TYPE_MOVIE)
+                            .build()
+            );
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
## 배경

Android 17에서 배경 오디오 API 변경에 대응하기 위한 마이그레이션 작업입니다. (우선순위: **P2**)

`MediaPlayer.setAudioStreamType()`은 API 21부터 deprecated 되었으며, `setAudioAttributes()` API로 교체가 필요합니다.

## 변경 사항

- **파일**: `app/src/main/java/com/sendbird/desk/android/sample/activity/chat/MediaPlayerActivity.java`
- `mMediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC)` → `mMediaPlayer.setAudioAttributes(...)` 로 교체
- `AudioManager` import 제거, `AudioAttributes` import 추가
- `minSdk = 21`이므로 버전 분기 없이 `AudioAttributes` API 직접 사용

## 테스트 계획

- [ ] 동영상 파일 재생 시 오디오 정상 출력 확인
- [ ] 배경 오디오 동작 확인 (포커스 처리 등)
- [ ] API 21 이상 기기에서 빌드 및 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)